### PR TITLE
Add windows binding

### DIFF
--- a/.github/workflows/publish-go-package.yaml
+++ b/.github/workflows/publish-go-package.yaml
@@ -20,6 +20,7 @@ jobs:
           brew install protobuf
           brew install aarch64-unknown-linux-gnu
           brew install x86_64-unknown-linux-gnu
+          brew install mingw-w64
           cargo install --version 0.22.0 uniffi_bindgen
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v3
@@ -43,8 +44,10 @@ jobs:
           sudo chmod 600 ~/.ssh/id_rsa
           ssh-add ~/.ssh/id_rsa
           make init
+          rustup target add x86_64-pc-windows-gnu
           cargo build --release --target aarch64-unknown-linux-gnu
           cargo build --release --target x86_64-unknown-linux-gnu
+          cargo build --release --target x86_64-pc-windows-gnu
           make golang-darwin
       - name: Copy binding
         working-directory: build/libs/sdk-bindings/ffi/golang/breez/breez_sdk
@@ -57,6 +60,7 @@ jobs:
           cp x86_64-apple-darwin/release/libbreez_sdk_bindings.dylib ../../../dist/breez_sdk/lib/darwin-amd64
           cp aarch64-unknown-linux-gnu/release/libbreez_sdk_bindings.so ../../../dist/breez_sdk/lib/linux-aarch64
           cp x86_64-unknown-linux-gnu/release/libbreez_sdk_bindings.so ../../../dist/breez_sdk/lib/linux-amd64
+          cp x86_64-pc-windows-gnu/release/breez_sdk_bindings.dll ../../../dist/breez_sdk/lib/windows-amd64
       - name: Tag the Go bindings
         working-directory: dist
         run: |
@@ -65,6 +69,7 @@ jobs:
           git add breez_sdk/lib/darwin-amd64/libbreez_sdk_bindings.dylib
           git add breez_sdk/lib/linux-aarch64/libbreez_sdk_bindings.so
           git add breez_sdk/lib/linux-amd64/libbreez_sdk_bindings.so
+          git add breez_sdk/lib/windows-amd64/breez_sdk_bindings.dll
           git commit -m "Update Breez SDK Go bindings to version ${{ inputs.version }}"
           git push
           git tag ${{ inputs.version }} -m "${{ inputs.version }}"

--- a/breez_sdk/cgo.go
+++ b/breez_sdk/cgo.go
@@ -6,6 +6,7 @@ package breez_sdk
 #cgo darwin,arm64 LDFLAGS: -Wl,-rpath,${SRCDIR}/lib/darwin-aarch64 -L${SRCDIR}/lib/darwin-aarch64
 #cgo linux,amd64 LDFLAGS: -Wl,-rpath,${SRCDIR}/lib/linux-amd64 -L${SRCDIR}/lib/linux-amd64
 #cgo linux,arm64 LDFLAGS: -Wl,-rpath,${SRCDIR}/lib/linux-aarch64 -L${SRCDIR}/lib/linux-aarch64
+#cgo windows,amd64 LDFLAGS: -Wl,-rpath,${SRCDIR}/lib/windows-amd64 -L${SRCDIR}/lib/windows-amd64
 */
 import "C"
 

--- a/breez_sdk/lib/dummy.go
+++ b/breez_sdk/lib/dummy.go
@@ -6,4 +6,5 @@ import (
 	_ "github.com/breez/breez-sdk-go/breez_sdk/lib/darwin-amd64"
 	_ "github.com/breez/breez-sdk-go/breez_sdk/lib/linux-aarch64"
 	_ "github.com/breez/breez-sdk-go/breez_sdk/lib/linux-amd64"
+	_ "github.com/breez/breez-sdk-go/breez_sdk/lib/windows-amd64"
 )

--- a/breez_sdk/lib/windows-amd64/dummy.go
+++ b/breez_sdk/lib/windows-amd64/dummy.go
@@ -1,0 +1,2 @@
+// See https://github.com/golang/go/issues/26366.
+package windows_amd64


### PR DESCRIPTION
This PR adds a windows binding to the published Go package. It uses mingw-w64 as the cross-compiler and builds for the x86_64-pc-windows-gnu target.

The resulting binding is as yet untested on windows using the CI, but the package can theoretically be cross-compiled and tested on a windows VirtualBox.